### PR TITLE
Use bufio.ReadString instead of fmt.Scanln so that spaces are handled

### DIFF
--- a/prompt.go
+++ b/prompt.go
@@ -1,16 +1,22 @@
 package prompt
 
-import "github.com/howeyc/gopass"
+import (
+	"os"
+
+	"github.com/howeyc/gopass"
+)
+
 import "strings"
 import "strconv"
 import "fmt"
+import "bufio"
 
 // String prompt.
 func String(prompt string, args ...interface{}) string {
-	var s string
 	fmt.Printf(prompt+": ", args...)
-	fmt.Scanln(&s)
-	return s
+	reader := bufio.NewReader(os.Stdin)
+	bytes, _, _ := reader.ReadLine()
+	return string(bytes)
 }
 
 // String prompt (required).


### PR DESCRIPTION
Use bufio.ReadString instead of fmt.Scanln so that spaces are handled correctly [Fixes #3]
